### PR TITLE
Bug Fixes

### DIFF
--- a/Assets/Prefabs/UI/Inventory/Card.prefab
+++ b/Assets/Prefabs/UI/Inventory/Card.prefab
@@ -19,7 +19,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &5982405813128526298
 RectTransform:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/TestScenes/GameplayTestScene.unity
+++ b/Assets/Scenes/TestScenes/GameplayTestScene.unity
@@ -633,51 +633,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1439851176
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1439851178}
-  - component: {fileID: 1439851177}
-  m_Layer: 0
-  m_Name: TempObj
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &1439851177
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1439851176}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: aa6f0169cc8cb3e40b5a03c2512046e6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  defaultCardHandSO: {fileID: 11400000, guid: a83d80bbbe833b3418fa6c7ccce616bd, type: 2}
---- !u!4 &1439851178
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1439851176}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -24, y: 2.5, z: 0.20000017}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 6
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1466402346
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Meta/CurrencySystem/CurrencyDisplay.cs
+++ b/Assets/Scripts/Meta/CurrencySystem/CurrencyDisplay.cs
@@ -25,7 +25,7 @@ namespace Meta.CurrencySystem
 
         private void UpdateDisplay(int amount)
         {
-            textMesh.text = $"SoftCurrency: {amount}";
+            textMesh.text = amount.ToString();
         } 
     }
 }


### PR DESCRIPTION
- Fixed error when loading the GameplayTestScene from the main scene due to a deprecated TemporaryCardHandCreator.
- Fixed normal currency display also writing out "Normal currency: " together with the value, which ended up taking to much space.
- Fixed inventory cards being active when loaded instead of being hidden until they have a value.